### PR TITLE
Crystal 1.0.0 compability

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -9,3 +9,5 @@ dependencies:
     github: luislavena/radix
 
 license: MIT
+
+crystal: ">= 0.35.0"


### PR DESCRIPTION
`crystal` property is required for crystal 1.0.0 compability